### PR TITLE
add Aptakube as a kubernetes tool

### DIFF
--- a/data/en/items/operations.json
+++ b/data/en/items/operations.json
@@ -361,6 +361,10 @@
       {
         "title": "k9s",
         "url": "https://k9scli.io/"
+      },
+      {
+        "title": "Aptakube",
+        "url": "https://aptakube.com"
       }
     ],
     "tags": [


### PR DESCRIPTION
Hi there 👋

Just adding aptakube as an alternative kubernetes GUI.

It works natively with AKS, including az cli and azure/kubelogin for authentication. I have plenty of happy users using it with AKS so I thought it would be beneficial to have it here as an alternative for anyone to explore

Thanks!